### PR TITLE
Removed deprecated -e flag for docker login

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq default-jdk
-  - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+  - docker login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD"
   - docker build -t inaetics/buildroot_minimum_celix buildroot_minimum_celix
   - docker build -t inaetics/cagent_builder cagent_builder
   - docker run inaetics/cagent_builder build_script > cagent_builder.sh && chmod +x cagent_builder.sh


### PR DESCRIPTION
Removed the -e flag from the .travis.yml since the flag no longer exists is the latest Docker versions.

Info: https://docs.docker.com/engine/reference/commandline/login/